### PR TITLE
Typo gpdata instead of data

### DIFF
--- a/inc/plugins/MyGoogle+Connect/class_google.php
+++ b/inc/plugins/MyGoogle+Connect/class_google.php
@@ -608,7 +608,7 @@ class MyGoogle
 			
 			if ($db->field_exists($locationid, "userfields")) {
 			
-				foreach($gpdata['placesLived'] as $place) {
+				foreach($data['placesLived'] as $place) {
 				
 					if ($place['primary']) {
 					
@@ -619,7 +619,7 @@ class MyGoogle
 					
 				}
 				
-				$userfield[$locationid] = $db->escape_string($data['placesLived']);
+				$userfield[$locationid] = $db->escape_string($location);
 				
 			}
 			


### PR DESCRIPTION
Warning [2] Invalid argument supplied for foreach() - Line: 611 - File: class_google.php PHP 5.4.22 (Linux)

To reproduce:
Login with a normal account that hasn't been connect to google.
Then go to usercp and attach google.
Relogin.

And in any case $gpdata doesn't exist in that context, and I did print_r on $data and it does contain the request data "placesLived"

Warning [2] preg_match() expects parameter 2 to be string, array given - Line: 6561 - File: inc/functions.php PHP 5.4.22 (Linux)

Backtracing we get to line 622 in class_google.php, it was trying to escape_string an array, but the location was (now) properly fetched above so just used that variable instead.

Tested and it does update location now.
